### PR TITLE
Wrap batch iteration in a loop to consume entire input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -177,13 +177,18 @@ fn main() -> Result<(), ParquetError> {
 
     let mut writer = ArrowWriter::try_new(output, reader.schema(), Some(props.build()))?;
 
-    match reader.next() {
-        Ok(batch) => {
-            if let Some(batch) = batch {
-                writer.write(&batch)?
+    loop {
+        match reader.next() {
+            Ok(batch) => {
+                if let Some(batch) = batch {
+                    writer.write(&batch)?
+                }
+                else {
+                    break;
+                }
             }
+            Err(error) => return Err(error.into()),
         }
-        Err(error) => return Err(error.into()),
     }
 
     match writer.close() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -182,8 +182,7 @@ fn main() -> Result<(), ParquetError> {
             Ok(batch) => {
                 if let Some(batch) = batch {
                     writer.write(&batch)?
-                }
-                else {
+                } else {
                     break;
                 }
             }


### PR DESCRIPTION
I think this is all that’s needed to address #1. I used the cli tools (e.g. parquet-rowcount) from the [parquet repo](https://github.com/apache/arrow-rs/tree/master/parquet) validate the output.

Before
```zsh
; wc -l wiki-articles.json.1M 
1048576 wiki-articles.json.1M

; target/debug/json2parquet wiki-articles.json.1M wiki.par.before

; parquet-rowcount wiki.par.before
File wiki.par.before: rowcount=1024 
```

After

```zsh
; target/debug/json2parquet wiki-articles.json.1M wiki.par.after 

; parquet-rowcount wiki.par.after                      
File wiki.par.after: rowcount=1048576
```
